### PR TITLE
FIXED the CustomerSearch Panel

### DIFF
--- a/src/components/pages/CustomerPanelPage.vue
+++ b/src/components/pages/CustomerPanelPage.vue
@@ -1,20 +1,15 @@
 <template>
   <div v-if="isLoadingPage"></div>
   <div v-else>
-    <div
-      v-if="
-        currentCustomer.accountApprovalStatus == 'VERIFIED' ||
-        currentCustomer.accountApprovalStatus == 'UNVERIFIED'
-      "
-      class="profile-page"
-    >
+    <div v-if="currentCustomer.accountApprovalStatus == 'VERIFIED' ||
+        currentCustomer.accountApprovalStatus == 'UNVERIFIED'"
+      class="profile-page">
       <div class="d-flex">
         <div class="nav-panel p-4 rounded-start">
           <CustomerPanelNavigation
             :currentPanel="currentPanel"
             :isNavigationDisabled="isNavigationDisabled"
-            @selectPanel="selectPanel"
-          />
+            @selectPanel="selectPanel" />
         </div>
         <div class="content-panel rounded-end flex-grow-1">
           <div v-if="currentPanel === 'Overview'">
@@ -26,17 +21,15 @@
           <div v-else-if="currentPanel === 'Create Transaction'">
             <CustomerPanelNewTransaction
               :currentCustomer="currentCustomer"
-              @updateCustomerAccountData="refreshCustomerAccounts"
-            />
+              @updateCustomerAccountData="refreshCustomerAccounts" />
           </div>
           <div v-else-if="currentPanel === 'Search Customer'">
-            <CustomerPanelSearchCustomer :currentCustomer="currentCustomer" />
+            <CustomerPanelSearchCustomer />
           </div>
           <div v-else-if="currentPanel === 'Settings'">
             <CustomerPanelSettings
               :currentCustomer="currentCustomer"
-              @customerUpdated="updateCustomerDetails"
-            />
+              @customerUpdated="updateCustomerDetails" />
           </div>
         </div>
       </div>

--- a/src/stores/customerProfileStore.js
+++ b/src/stores/customerProfileStore.js
@@ -2,7 +2,7 @@ import { defineStore } from 'pinia';
 import axios from '../axios_auth';
 import Swal from 'sweetalert2';
 
-export const useCustomerProfileStore = defineStore('customer', {
+export const useCustomerProfileStore = defineStore('customerprofile', {
     state: () => ({
         currentCustomer: {},
     }),


### PR DESCRIPTION
Fixed the Customer search panel.
Removed the unused prop from CustomerSearch that was not the issue.

The issue was, because of the customerPanelPage now using stores for fetching data, I had the id of the store as customer exactly the same as "searchCustomerIbanByNameStore". So just by changing the name in customerProfileStore, I fixed the page breaking issue.